### PR TITLE
npm audit corrupts non-tty's

### DIFF
--- a/cli/flags.rs
+++ b/cli/flags.rs
@@ -62,7 +62,9 @@ pub struct DenoFlags {
 
 static ENV_VARIABLES_HELP: &str = "ENVIRONMENT VARIABLES:
     DENO_DIR        Set deno's base directory
-    NO_COLOR        Set to disable color";
+    NO_COLOR        Set to disable color
+    HTTP_PROXY      Set proxy address for HTTP requests (module downloads, fetch)
+    HTTPS_PROXY     Set proxy address for HTTPS requests (module downloads, fetch)";
 
 fn add_run_args<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
   app

--- a/cli/tests/043_xeval_delim2.test
+++ b/cli/tests/043_xeval_delim2.test
@@ -1,3 +1,0 @@
-args: xeval -d MADAM console.log($);
-input: !MADMADAMADAM!
-output: tests/043_xeval_delim2.out

--- a/cli/tests/044_bad_resource.test
+++ b/cli/tests/044_bad_resource.test
@@ -1,4 +1,0 @@
-args: run --reload --allow-read tests/044_bad_resource.ts
-output: tests/044_bad_resource.ts.out
-check_stderr: true
-exit_code: 1

--- a/cli/tests/044_bad_resource.ts
+++ b/cli/tests/044_bad_resource.ts
@@ -1,5 +1,5 @@
 async function main(): Promise<void> {
-  const file = await Deno.open("Cargo.toml", "r");
+  const file = await Deno.open("044_bad_resource.ts", "r");
   file.close();
   await file.seek(10, 0);
 }

--- a/cli/tests/045_proxy_client.ts
+++ b/cli/tests/045_proxy_client.ts
@@ -1,0 +1,7 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+async function main(): Promise<void> {
+  const res = await fetch("http://deno.land/welcome.ts");
+  console.log(`Response http: ${await res.text()}`);
+}
+
+main();

--- a/cli/tests/045_proxy_test.ts
+++ b/cli/tests/045_proxy_test.ts
@@ -1,0 +1,75 @@
+// Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
+import {
+  serve,
+  ServerRequest
+} from "../../js/deps/https/deno.land/std/http/server.ts";
+import { assertEquals } from "../../js/deps/https/deno.land/std/testing/asserts.ts";
+
+const addr = Deno.args[1] || "127.0.0.1:4555";
+
+async function proxyServer(): Promise<void> {
+  const server = serve(addr);
+
+  console.log(`Proxy server listening on http://${addr}/`);
+  for await (const req of server) {
+    proxyRequest(req);
+  }
+}
+
+async function proxyRequest(req: ServerRequest): Promise<void> {
+  console.log(`Proxy request to: ${req.url}`);
+  const resp = await fetch(req.url, {
+    method: req.method,
+    headers: req.headers
+  });
+  req.respond(resp);
+}
+
+async function testFetch(): Promise<void> {
+  const c = Deno.run({
+    args: [
+      Deno.execPath(),
+      "--no-prompt",
+      "--reload",
+      "--allow-net",
+      "045_proxy_client.ts"
+    ],
+    stdout: "piped",
+    env: {
+      HTTP_PROXY: `http://${addr}`
+    }
+  });
+
+  const status = await c.status();
+  assertEquals(status.code, 0);
+  c.close();
+}
+
+async function testModuleDownload(): Promise<void> {
+  const http = Deno.run({
+    args: [
+      Deno.execPath(),
+      "--no-prompt",
+      "--reload",
+      "fetch",
+      "http://deno.land/welcome.ts"
+    ],
+    stdout: "piped",
+    env: {
+      HTTP_PROXY: `http://${addr}`
+    }
+  });
+
+  const httpStatus = await http.status();
+  assertEquals(httpStatus.code, 0);
+  http.close();
+}
+
+async function main(): Promise<void> {
+  proxyServer();
+  await testFetch();
+  await testModuleDownload();
+  Deno.exit(0);
+}
+
+main();

--- a/cli/tests/045_proxy_test.ts.out
+++ b/cli/tests/045_proxy_test.ts.out
@@ -1,0 +1,3 @@
+Proxy server listening on [WILDCARD]
+Proxy request to: http://deno.land/welcome.ts
+Proxy request to: http://deno.land/welcome.ts

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -304,6 +304,19 @@ itest!(_042_dyn_import_evalcontext {
   output: "042_dyn_import_evalcontext.ts.out",
 });
 
+itest!(_043_xeval_delim2 {
+  args: "xeval -d MADAM console.log($)",
+  input: Some("!MADMADAMADAM!"),
+  output: "043_xeval_delim2.out",
+});
+
+itest!(_044_bad_resource {
+  args: "run --reload --allow-read 044_bad_resource.ts",
+  output: "044_bad_resource.ts.out",
+  check_stderr: true,
+  exit_code: 1,
+});
+
 itest!(async_error {
   exit_code: 1,
   args: "run --reload async_error.ts",

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -427,6 +427,7 @@ itest!(error_013_missing_script {
 itest!(error_014_catch_dynamic_import_error {
   args: "error_014_catch_dynamic_import_error.js --reload --allow-read",
   output: "error_014_catch_dynamic_import_error.js.out",
+  exit_code: 1,
 });
 
 itest!(error_015_dynamic_import_permissions {
@@ -548,4 +549,9 @@ itest!(wasm {
 itest!(wasm_async {
   args: "wasm_async.js",
   output: "wasm_async.out",
+});
+
+itest!(top_level_await {
+  args: "--allow-read top_level_await.js",
+  output: "top_level_await.out",
 });

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -317,6 +317,11 @@ itest!(_044_bad_resource {
   exit_code: 1,
 });
 
+itest!(_045_proxy {
+  args: "run --allow-net --allow-env --allow-run --reload 045_proxy_test.ts",
+  output: "045_proxy_test.ts.out",
+});
+
 itest!(async_error {
   exit_code: 1,
   args: "run --reload async_error.ts",

--- a/cli/tests/top_level_await.js
+++ b/cli/tests/top_level_await.js
@@ -1,0 +1,3 @@
+const buf = await Deno.readFile("hello.txt");
+const n = await Deno.stdout.write(buf);
+console.log(`\n\nwrite ${n}`);

--- a/cli/tests/top_level_await.out
+++ b/cli/tests/top_level_await.out
@@ -1,0 +1,3 @@
+Hello world!
+
+write 12

--- a/core/libdeno/api.cc
+++ b/core/libdeno/api.cc
@@ -120,8 +120,9 @@ void deno_init() {
     // remove this to make it work asynchronously too. But that requires getting
     // PumpMessageLoop and RunMicrotasks setup correctly.
     // See https://github.com/denoland/deno/issues/2544
-    const char* argv[2] = {"", "--no-wasm-async-compilation"};
-    int argc = 2;
+    const char* argv[3] = {"", "--no-wasm-async-compilation",
+                           "--harmony-top-level-await"};
+    int argc = 3;
     v8::V8::SetFlagsFromCommandLine(&argc, const_cast<char**>(argv), false);
   }
 }

--- a/core/libdeno/modules.cc
+++ b/core/libdeno/modules.cc
@@ -147,8 +147,12 @@ void deno_mod_evaluate(Deno* d_, void* user_data, deno_mod id) {
   if (status == Module::kInstantiated) {
     bool ok = !module->Evaluate(context).IsEmpty();
     status = module->GetStatus();  // Update status after evaluating.
-    CHECK_IMPLIES(ok, status == Module::kEvaluated);
-    CHECK_IMPLIES(!ok, status == Module::kErrored);
+    if (ok) {
+      // Note status can still be kErrored even if we get ok.
+      CHECK(status == Module::kEvaluated || status == Module::kErrored);
+    } else {
+      CHECK_EQ(status, Module::kErrored);
+    }
   }
 
   switch (status) {

--- a/gclient_config.py
+++ b/gclient_config.py
@@ -1,7 +1,7 @@
 # Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 solutions = [
     {
-        'url': 'https://chromium.googlesource.com/v8/v8.git@7.9.8',
+        'url': 'https://chromium.googlesource.com/v8/v8.git@7.9.110',
         'name': 'v8',
         'deps_file': 'DEPS',
         'custom_deps': {

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -127,13 +127,12 @@ def generate_gn_args(mode):
     if "DENO_BUILD_ARGS" in os.environ:
         out += os.environ["DENO_BUILD_ARGS"].split()
 
-    cacher = find_executable("sccache")
-    if not os.path.exists(cacher):
-        cacher = third_party.get_prebuilt_tool_path("sccache")
+    # Check if sccache is in the path, and if so we set cc_wrapper.
+    cc_wrapper = find_executable("sccache")
+    if not cc_wrapper:
+        cc_wrapper = third_party.get_prebuilt_tool_path("sccache")
 
-    # Check if ccache or sccache are in the path, and if so we set cc_wrapper.
-    cc_wrapper = cacher
-    if cc_wrapper:
+    if os.path.exists(cc_wrapper):
         # The gn toolchain does not shell escape cc_wrapper, so do it here.
         out += ['cc_wrapper=%s' % gn_string(shell_quote(cc_wrapper))]
         if os.name == "nt":

--- a/website/manual.md
+++ b/website/manual.md
@@ -712,6 +712,8 @@ SUBCOMMANDS:
 ENVIRONMENT VARIABLES:
     DENO_DIR        Set deno's base directory
     NO_COLOR        Set to disable color
+    HTTP_PROXY      Set proxy address for HTTP requests (module downloads, fetch)
+    HTTPS_PROXY     Set proxy address for HTTPS requests (module downloads, fetch)
 ```
 
 ### Environmental variables
@@ -876,12 +878,12 @@ $ deno install awesome_cli https://example.com/awesome/cli.ts
 
 ## Proxies
 
-Deno supports proxies.
+Deno supports proxies for module downloads and `fetch` API.
 
-`HTTP_PROXY` and `HTTPS_PROXY` environmental variables are used to configure
-them.
+Proxy configuration is read from environmental variables: `HTTP_PROXY` and
+`HTTPS_PROXY`.
 
-For Windows if environmental variables are not found Deno will fall back to
+In case of Windows if environmental variables are not found Deno falls back to
 reading proxies from registry.
 
 ## Import maps


### PR DESCRIPTION
<!--
Before submitting a PR read https://deno.land/manual.html#contributing
-->
