### PR TITLE
Create a new pull request by comparing changes across two branches

### DIFF
--- a/ext/http/lib.rs
+++ b/ext/http/lib.rs
@@ -769,7 +769,11 @@ async fn op_http_write_resource(
 
     match &mut *wr {
       HttpResponseWriter::Body(body) => {
-        if let Err(err) = body.write_all(&view).await {
+        let mut result = body.write_all(&view).await;
+        if result.is_ok() {
+          result = body.flush().await;
+        }
+        if let Err(err) = result {
           assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe);
           // Don't return "broken pipe", that's an implementation detail.
           // Pull up the failure associated with the transport connection instead.


### PR DESCRIPTION
When streaming a resource in ext/http, with compression enabled, we didn't flush individual chunks. This became very problematic when we enabled `req.body` from `fetch` for FastStream recently.

This commit now correctly flushes each resource chunk after compression.

<!--
Before submitting a PR, please read http://deno.land/manual/contributing

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(std/http): Fix race condition in server
    - docs(console): Update docstrings
    - feat(doc): Handle nested reexports

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. Ensure there is a related issue and it is referenced in the PR text.
3. Ensure there are tests that cover the changes.
4. Ensure `cargo test` passes.
5. Ensure `./tools/format.js` passes without changing files.
6. Ensure `./tools/lint.js` passes.
-->
